### PR TITLE
More translations for user-visible strings

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -11,6 +11,7 @@
   "helloWorld": "Hello World",
   "appTitle": "LibGen Book Search",
   "search": "Search",
+  "searching": "Searching...",
   "noResults": "No results.",
   "publisher": "Publisher",
   "language": "Language",
@@ -32,5 +33,10 @@
   "libgenServerSelection": "Libgen server selection",
   "libgenPingDescription": "This feature pings the following servers and automatically selects the fastest one:",
   "selectFastestServer": "Select fastest server",
-  "pingStatus": ""
+  "pingStatus": "",
+  "downloadLink": "Download link",
+  "noContentLength": "Warning: No content-length header was received.",
+  "opening": "Opening",
+  "downloadComplete": "Download complete!",
+  "downloading": "Downloading"
 }

--- a/locales/hu/translation.json
+++ b/locales/hu/translation.json
@@ -11,6 +11,7 @@
   "helloWorld": "Hello Világ",
   "appTitle": "LibGen Könyv Kereső",
   "search": "Keresés",
+  "searching": "Keresés...",
   "noResults": "Nincs találat.",
   "publisher": "Kiadó",
   "language": "Nyelv",
@@ -32,5 +33,10 @@
   "libgenServerSelection": "Libgen szerver kiválasztása",
   "libgenPingDescription": "Ez a funkció megpingeli a következő szervereket, és automatikusan kiválasztja a leggyorsabbat:",
   "selectFastestServer": "Leggyorsabb szerver kiválasztása",
-  "pingStatus": ""
+  "pingStatus": "",
+  "downloadLink": "Letöltési link",
+  "noContentLength": "Figyelmeztetés: Nem érkezett content-length fejléc.",
+  "opening": "Megnyitás",
+  "downloadComplete": "Letöltés kész!",
+  "downloading": "Letöltés"
 }

--- a/pages/settingsSite.html
+++ b/pages/settingsSite.html
@@ -8,7 +8,7 @@
 
   <button class="button" id="saveBtn" data-i18n="save">Mentés</button>
 
-  <p id="saveStatus" style="margin-top: 10px; display: none;"><span data-i18n="directorySaved">Könyvtár mentve:</span> <span id="savePath"></span></p>
+  <p id="saveStatus" style="margin-top: 10px;" hidden><span data-i18n="directorySaved">Könyvtár mentve:</span> <span id="savePath"></span></p>
 
   <h3 data-i18n="libgenServerSelection">Libgen szerver kiválasztása</h3>
   <p data-i18n="libgenPingDescription">

--- a/renderer.js
+++ b/renderer.js
@@ -75,7 +75,13 @@ async function showPage(page) {
     if (page === 'downloadProgress') {
       window.electronAPI.onDownloadStatus((event, status) => {
         const statusDiv = document.getElementById('downloadStatus');
-        if (statusDiv) {
+        if (!statusDiv) return;       
+        if (typeof status === 'object' && status.key && status.value) {
+          statusDiv.textContent = i18next.t(status.key) + ": " + status.value;
+        }
+        else if (typeof status === 'object' && status.key) {
+          statusDiv.textContent = i18next.t(status.key);
+        } else {
           statusDiv.textContent = status;
         }
       });
@@ -139,7 +145,7 @@ async function showPage(page) {
         const newPath = dirInput.value;
         const result = await window.electronAPI.setConfig(newPath);
         if (result.success) {
-          status.style.display= 'block';
+          status.hidden = false;
           savePath.textContent = `${result.path}`;
           status.style.color = 'green';
           currentDirText.textContent = result.path;
@@ -211,8 +217,8 @@ async function performSearch() {
   const table = document.getElementById('resultsTable');
   const tbody = table.querySelector('tbody');
 
-  status.textContent = 'Keresés...';
-  table.style.display = 'none';
+  status.textContent = i18next.t('searching');
+  table.hidden = true;
   tbody.innerHTML = '';
 
   const results = await window.electronAPI.fetchLibgen(query);
@@ -227,7 +233,7 @@ async function performSearch() {
   }
 
   status.textContent = `${results.length} results.`;
-  table.style.display = 'table';
+  table.hidden = false;
 
   results.forEach(book => {
     const row = document.createElement('tr');


### PR DESCRIPTION
User-visible hungarian strings are now i18n keys.

For download statuses, instead of just the string, an object with an i18n key is sent, so that it can be translated in the renderer. Note: download-error event left untranslated as download-error is not currently used in renderer.

Also: for temporarily invisible elements (table and status on the search page) `element.hidden = true` is used instead of `element.style.display = "none"`